### PR TITLE
Include nuget.org configuration

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,11 @@
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        <add key="MainLatest" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-MainLatest/nuget/v3/index.json" protocolVersion="3" />
+        <add key="LabsFeed" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" protocolVersion="3" />
+    </packageSources>
+    <disabledPackageSources>
+        <clear />
+    </disabledPackageSources>
+</configuration>


### PR DESCRIPTION
Integrating nuget.org configuration to ensure seamless initial build for new developers, eliminating the need for extra settings.

The provided configuration file has been adopted from the [CommunityToolkit repository](https://github.com/CommunityToolkit/Labs-Windows/blob/main/nuget.config). By default, it clears all sources before adding the toolkit source. Consequently, if local sources are required, such as for local package debugging, modifications to this configuration file will be necessary, specifically, the clear element needs to be removed.

Here is the configuration file for reference:

```xml
<configuration>
  <packageSources>
    <clear />
    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
    <add key="MainLatest" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-MainLatest/nuget/v3/index.json" protocolVersion="3" />
    <add key="LabsFeed" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" protocolVersion="3" />
  </packageSources>
  <disabledPackageSources>
    <clear />
  </disabledPackageSources>
</configuration>
```