### PR TITLE
Fixed .Net Native runtime exception

### DIFF
--- a/src/MicaApps.Mail.UWP/MicaApps.Mail.UWP.csproj
+++ b/src/MicaApps.Mail.UWP/MicaApps.Mail.UWP.csproj
@@ -316,7 +316,7 @@
       <Version>0.1.10</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.Sqlite">
-      <Version>7.0.8</Version>
+      <Version>7.0.12</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory">
       <Version>8.0.0-preview.4.23259.5</Version>
@@ -325,10 +325,10 @@
       <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph">
-      <Version>5.19.0</Version>
+      <Version>5.12.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Client">
-      <Version>4.55.0</Version>
+      <Version>4.56.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>


### PR DESCRIPTION
1. 现成的 [issue](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2025)，与 [kiota-serialization-json](https://github.com/microsoft/kiota-serialization-json-dotnet) 有关。
2. 似乎已经在 [PR 86](https://github.com/microsoft/kiota-serialization-json-dotnet/pull/86) 解决但是可能是还没有同步到Microsoft.Graph，因此Graph最新版还是崩的，必须降级至5.12.0版本。
3. 大设计师嗡嗡嗡的烦死了，简简单单的一个事情像牛皮癣一样到处找人解决，仿佛世纪大难题，我只是为了拯救各位于大设计师的小广告牛皮癣之中，不用谢我。